### PR TITLE
modify workflow to allow multiple files corruption

### DIFF
--- a/experiments/workflows/01-bypass-staging-1-cache-corrupt-v2/iris-experiment-driver
+++ b/experiments/workflows/01-bypass-staging-1-cache-corrupt-v2/iris-experiment-driver
@@ -3,6 +3,8 @@
 corruptsite=$1
 workdir=$2
 runid=$3
+CORRUPT_TIMES=$4
+CORRUPT_PROB=$5
 
 logfile=${workdir}/${corruptsite}_${runid}_corrupt.log
 tmplogfile=/tmp/iris_corrupt_${corruptsite}_${runid}.log  # so control machine can grap it easily
@@ -12,13 +14,16 @@ echo
 echo `date` "Corrupting the cache at ${corruptsite}..."
 echo $(date +%s) CORRUPT_START ${corruptsite} > ${logfile}
 # cj_storage.py might be confused about the state, so "revert" first
-ssh ${corruptsite} "sudo /root/chaos-jungle/storage/cj_storage.py --revert -f /cache/uc-staging.data-plane-~$USER-inputs-Visual_Signaling_By_Signal_Corps_United_States_Army.txt.cached --onetime" >/dev/null 2>&1
-ssh ${corruptsite} "sudo /root/chaos-jungle/storage/cj_storage.py -f /cache/uc-staging.data-plane-~$USER-inputs-Visual_Signaling_By_Signal_Corps_United_States_Army.txt.cached --onetime"
-
+ssh ${corruptsite} "sudo /root/chaos-jungle/storage/cj_storage.py --revert" >/dev/null 2>&1
+for (( j=1; j<=${CORRUPT_TIMES}; j++ ))
+do
+ssh ${corruptsite} "sudo /root/chaos-jungle/storage/cj_storage.py -d /cache/ -f \"uc-staging.data-plane-~$USER*\" -p ${CORRUPT_PROB} -r --onetime"
+done
 sleep 1m
 
 echo
 echo `date` "Clearing the cache at ${corruptsite}..."
+ssh ${corruptsite} "sudo /root/chaos-jungle/storage/cj_storage.py --revert" >/dev/null 2>&1
 ssh ${corruptsite} "sudo rm -f /cache/uc-staging.data-plane-~$USER*"
 echo $(date +%s) CORRUPT_END ${corruptsite} >> ${logfile}
 cp  ${logfile} ${tmplogfile}


### PR DESCRIPTION
take 2 more parameters:

   `parser.add_argument(
                "-m",
                "--corrupt_times",
                help="This is the count that corruption command will be issued, for multiple files corruption"
            )

    parser.add_argument(
                "-p",
                "--corrupt_prob",
                help="The probability of corruption (arg for chaos-jungle)"
            )`